### PR TITLE
Upgrading Monado

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ FetchContent_Declare(tinygltf URL https://github.com/syoyo/tinygltf/archive/refs
 FetchContent_Declare(boostpfr URL https://github.com/boostorg/pfr/archive/refs/tags/2.0.3.tar.gz)
 FetchContent_Declare(monado
     GIT_REPOSITORY   https://gitlab.freedesktop.org/monado/monado
-    GIT_TAG          3c1880448e7d23c9ecebbd08a31394c5f3ee4713
+    GIT_TAG          e9475b13137db2cca8571576b5381a70fb8180a5
     )
 
 

--- a/server/driver/wivrn_hmd.cpp
+++ b/server/driver/wivrn_hmd.cpp
@@ -36,6 +36,7 @@
 #include "util/u_var.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <stdio.h>
 #include <openxr/openxr.h>
 
@@ -179,7 +180,7 @@ static std::tuple<float, float> solve_foveation(float scale, float c)
 	return {a, b};
 }
 
-bool wivrn_hmd::wivrn_hmd_compute_distortion(xrt_device * xdev, int view_index, float u, float v, xrt_uv_triplet * result)
+bool wivrn_hmd::wivrn_hmd_compute_distortion(xrt_device * xdev, uint32_t view_index, float u, float v, xrt_uv_triplet * result)
 {
 	// u,v are in the output coordinates (sent to the encoder)
 	// result is in the input coordinates (from the application)

--- a/server/driver/wivrn_hmd.h
+++ b/server/driver/wivrn_hmd.h
@@ -25,6 +25,7 @@
 #include "view_list.h"
 #include "wivrn_session.h"
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 
@@ -43,7 +44,7 @@ class wivrn_hmd : public xrt_device
 
 	std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx;
 
-	static bool wivrn_hmd_compute_distortion(xrt_device * xdev, int view_index, float u, float v, xrt_uv_triplet * result);
+	static bool wivrn_hmd_compute_distortion(xrt_device * xdev, uint32_t view_index, float u, float v, xrt_uv_triplet * result);
 
 public:
 	wivrn_hmd(std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx,

--- a/server/target_instance_wivrn.cpp
+++ b/server/target_instance_wivrn.cpp
@@ -15,6 +15,7 @@
 #include "util/u_debug.h"
 #include "util/u_system_helpers.h"
 #include "util/u_trace_marker.h"
+#include "util/u_builders.h"
 
 #include <assert.h>
 
@@ -31,6 +32,7 @@ extern std::unique_ptr<TCP> tcp;
 static xrt_result_t
 wivrn_instance_create_system(struct xrt_instance * xinst,
                              struct xrt_system_devices ** out_xsysd,
+							 struct xrt_space_overseer ** out_xspovrs,
                              struct xrt_system_compositor ** out_xsysc)
 {
 	assert(out_xsysd != NULL);
@@ -62,6 +64,10 @@ wivrn_instance_create_system(struct xrt_instance * xinst,
 
 	*out_xsysd = xsysd;
 	*out_xsysc = xsysc;
+
+	struct xrt_space_overseer * xspovrs = NULL;
+	u_builder_create_space_overseer(xsysd, &xspovrs);
+	*out_xspovrs = xspovrs;
 
 	return xret;
 }


### PR DESCRIPTION
Upgraded Monado to [e9475b13](https://gitlab.freedesktop.org/monado/monado/-/commit/e9475b13137db2cca8571576b5381a70fb8180a5) from april. The commit after that, [86262e8b](https://gitlab.freedesktop.org/monado/monado/-/commit/86262e8b4e3ca0497d5846370cf281206cb92635) removed the global command pool utility function which is used by wivrn, so more a refactoring and vulkan knowldege is needed for that.

Mainly wanted to do this to make the output metrics to work.